### PR TITLE
Add toggle for DXGI_PRESENT_ALLOW_TEARING

### DIFF
--- a/FlipModelD3D12.sln
+++ b/FlipModelD3D12.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1433
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FlipModelD3D12", "FlipModelD3D12.vcxproj", "{11EB5ED2-B797-47AF-825D-23DF434C97B5}"
 EndProject
@@ -48,5 +48,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DCA0AB30-1CAF-4AE5-AD38-FADBCC4CCAEC}
 	EndGlobalSection
 EndGlobal

--- a/FlipModelD3D12.vcxproj
+++ b/FlipModelD3D12.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,30 +22,30 @@
     <ProjectGuid>{11EB5ED2-B797-47AF-825D-23DF434C97B5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WSI</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
     <ProjectName>FlipModelD3D12</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/FlipModelUniversal.vcxproj
+++ b/FlipModelUniversal.vcxproj
@@ -108,7 +108,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>
-      <AdditionalDependencies>mincore.lib;d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\arm; $(VCInstallDir)\lib\arm</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
@@ -125,7 +125,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Link>
-      <AdditionalDependencies>mincore.lib;d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\arm; $(VCInstallDir)\lib\arm</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
@@ -142,7 +142,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
-      <AdditionalDependencies>mincore.lib;d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
@@ -159,7 +159,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
-      <AdditionalDependencies>mincore.lib;d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store; $(VCInstallDir)\lib</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
@@ -193,7 +193,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalDependencies>mincore.lib;d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d12.lib;dxgi.lib;windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories); $(VCInstallDir)\lib\store\amd64; $(VCInstallDir)\lib\amd64</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>

--- a/FlipModelUniversal.vcxproj
+++ b/FlipModelUniversal.vcxproj
@@ -34,8 +34,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
   </PropertyGroup>
@@ -43,37 +43,37 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Choose your start up project, build and run.
 Requirements
 ============
 - Windows 10 or greater
-- Visual Studio 2015 or higher
+- Visual Studio 2017 or higher
 
 
  

--- a/Source/App.cpp
+++ b/Source/App.cpp
@@ -136,6 +136,7 @@ void App::Run()
 					"[%d] Fullscreen: F11" NEWLINE
 					"[%d] Vsync: Ctrl+K" NEWLINE
 					"[%d] Use Waitable Object: Ctrl+W" NEWLINE
+					"[%d] Allow Tearing: Ctrl+T" NEWLINE
 					"[%d] MaximumFrameLatency: Ctrl+,Ctrl-" NEWLINE
 					"[%d] BufferCount: +,-" NEWLINE
 					"[%d] FrameCount: [,]" NEWLINE
@@ -153,6 +154,7 @@ void App::Run()
 					m_fullscreen,
 					m_vsync,
 					m_swapchain_opts.create_time.use_waitable_object,
+					m_swapchain_opts.create_time.allow_tearing,
 					m_swapchain_opts.create_time.max_frame_latency,
 					m_swapchain_opts.create_time.swapchain_buffer_count,
 					m_swapchain_opts.create_time.gpu_frame_count,
@@ -270,6 +272,9 @@ void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::Ke
 	}
 	else if (vkey == VirtualKey::W && controlDown) {
 		m_swapchain_opts.create_time.use_waitable_object = !m_swapchain_opts.create_time.use_waitable_object;
+	}
+	else if (vkey == VirtualKey::T && controlDown) {
+		m_swapchain_opts.create_time.allow_tearing = !m_swapchain_opts.create_time.allow_tearing;
 	}
 	if (vkey == VirtualKey::Up) {
 		if(controlDown){
@@ -399,6 +404,7 @@ void App::serialize_swapchain_options(bool write)
 	serialize(settings, write, "overdraw_factor", opts->any_time.overdraw_factor, 8.0f);
 	serialize(settings, write, "cpu_draw_ms", opts->any_time.cpu_draw_ms, 8);
 	serialize(settings, write, "use_waitable_object", opts->create_time.use_waitable_object, 1);
+	serialize(settings, write, "allow_tearing", opts->create_time.allow_tearing, 0);
 	serialize(settings, write, "max_frame_latency", opts->create_time.max_frame_latency, 2);
 	serialize(settings, write, "swapchain_buffer_count", opts->create_time.swapchain_buffer_count, 3);
 	serialize(settings, write, "gpu_frame_count", opts->create_time.gpu_frame_count, 2);

--- a/Source/DX12Helpers.cpp
+++ b/Source/DX12Helpers.cpp
@@ -138,6 +138,7 @@ bool FrameQueue::Initialize(
 	ID2D1DeviceContext2 *D2DDeviceContext)
 {
 	this->~FrameQueue();
+	new (this) FrameQueue;
 
 	mNextFrameFence = 1;
 	mNextFrameIndex = 0;

--- a/Source/DX12Helpers.hpp
+++ b/Source/DX12Helpers.hpp
@@ -20,6 +20,7 @@
 #include <dxgi1_4.h>
 #include <d3d11on12.h>
 #include <d2d1_3.h>
+#include <string>
 #include <vector>
 
 #if D3D12_DYNAMIC_LINK

--- a/Source/sample_dx12.cpp
+++ b/Source/sample_dx12.cpp
@@ -327,6 +327,9 @@ static bool initialize_dx12_internal()
 	use_debug_layer = true;
 #endif
 
+	// Work around Windows 10 bug causing SetStablePowerState to fail
+	D3D12EnableExperimentalFeatures(0, nullptr, nullptr, nullptr);
+
 	// Enable the D2D debug layer.
 	D2D1_FACTORY_OPTIONS d2dFactoryOptions = {};
 	if (use_debug_layer) {

--- a/Source/sample_dx12.cpp
+++ b/Source/sample_dx12.cpp
@@ -32,7 +32,7 @@
 #include <d3d11on12.h>
 #include <d2d1_3.h>
 #include <dwrite.h>
-#include <dxgi1_4.h>
+#include <dxgi1_5.h>
 #include <DXGIDebug.h>
 #include <comdef.h>
 #include <wrl.h>
@@ -273,6 +273,7 @@ struct dx12_data
 	float4x4 ortho;
 
 	UINT64 startup_time;
+	bool allow_tearing;
 	EventViz::EventStream eviz;
 	PresentQueueStats pqs;
 	LatencyStatistics latency_stats;
@@ -354,6 +355,19 @@ static bool initialize_dx12_internal()
 		UINT dxgiFactory2Flags = 0;
 		if(use_debug_layer) dxgiFactory2Flags |= DXGI_CREATE_FACTORY_DEBUG;
 		CheckHresult(CreateDXGIFactory2(dxgiFactory2Flags, IID_PPV_ARGS(&dx12->dxgi_factory)));
+	}
+
+	// Test for tearing support
+	{
+		ComPtr<IDXGIFactory5> dxgi_factory5;
+		if (SUCCEEDED(dx12->dxgi_factory->QueryInterface(dxgi_factory5.GetAddressOf())))
+		{
+			UINT allowTearing = 0;
+			if (S_OK == dxgi_factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing)) && allowTearing)
+			{
+				dx12->allow_tearing = true;
+			}
+		}
 	}
 
 	// Create the device
@@ -713,7 +727,14 @@ static void present_dx12(frame_data *frame, UINT64 FrameBeginTime, int vsync, dx
 	auto chain = dx12->swap_chain.Get();
 
 	auto present_call = eviz->Start(EventViz::kCpuQueue, &event_types[EVENT_TYPE_PRESENT_CALL]);
-	chain->Present(SyncInterval, 0);
+	if (SyncInterval == 0 && dx12->allow_tearing && swapchain_opts.create_time.allow_tearing)
+	{
+		chain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
+	}
+	else
+	{
+		chain->Present(SyncInterval, 0);
+	}
 	eviz->End(present_call);
 
 	UINT color_index = frame->backbuffer_index % NUM_FRAME_COLORS;
@@ -749,6 +770,16 @@ static bool resize_dx12_internal(void *pHWND, void *pCoreWindow, float x_dips, f
 
 	bool create_depth = false;
 
+	UINT flags = 0;
+	if (swapchain_opts.create_time.use_waitable_object)
+	{
+		flags |= DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+	}
+	if (dx12->allow_tearing && swapchain_opts.create_time.allow_tearing)
+	{
+		flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+	}
+
 	DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {};
 	swap_chain_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	swap_chain_desc.Stereo = FALSE;
@@ -758,7 +789,7 @@ static bool resize_dx12_internal(void *pHWND, void *pCoreWindow, float x_dips, f
 	swap_chain_desc.Scaling = DXGI_SCALING_NONE;
 	swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 	swap_chain_desc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED; // unused
-	swap_chain_desc.Flags = swapchain_opts.create_time.use_waitable_object ? DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT : 0;
+	swap_chain_desc.Flags = flags;
 
 	// Create a new swap chain (initialization, parameters changed, etc)
 	if(!dx12->swap_chain)

--- a/Source/sample_dx12.hpp
+++ b/Source/sample_dx12.hpp
@@ -31,6 +31,7 @@ struct dx12_swapchain_options
 	// changing these will cause the device to be recreated
 	struct {
 		int use_waitable_object;
+		int allow_tearing;
 		int max_frame_latency;
 		int swapchain_buffer_count;
 		int gpu_frame_count;

--- a/Source/sample_main.cpp
+++ b/Source/sample_main.cpp
@@ -48,6 +48,7 @@ static void rebuild_hud_string(game_data *game)
 		"[%d] Fullscreen: F11" NEWLINE
 		"[%d] Vsync: Ctrl+K" NEWLINE
 		"[%d] Use Waitable Object: Ctrl+W" NEWLINE
+		"[%d] Allow Tearing: Ctrl+T" NEWLINE
 		"[%d] MaximumFrameLatency: Ctrl+,Ctrl-" NEWLINE
 		"[%d] BufferCount: +,-" NEWLINE
 		"[%d] FrameCount: [,]" NEWLINE
@@ -64,6 +65,7 @@ static void rebuild_hud_string(game_data *game)
 		screen.prefs.windowed==0,
 		screen.prefs.vsync,
 		swapchain_opts.create_time.use_waitable_object,
+		swapchain_opts.create_time.allow_tearing,
 		swapchain_opts.create_time.max_frame_latency,
 		swapchain_opts.create_time.swapchain_buffer_count,
 		swapchain_opts.create_time.gpu_frame_count,
@@ -178,6 +180,9 @@ void process_inputs(game_command *out_action)
 			}
 			if (message.keystroke.code == 'W' && (message.keystroke.modkeys & wsi::modControl)) {
 				swapchain_opts.create_time.use_waitable_object = !swapchain_opts.create_time.use_waitable_object;
+			}
+			if (message.keystroke.code == 'T' && (message.keystroke.modkeys & wsi::modControl)) {
+				swapchain_opts.create_time.allow_tearing = !swapchain_opts.create_time.allow_tearing;
 			}
 			if (message.keystroke.code == VK_F11) {
 				wsi::toggle_fullscreen();
@@ -361,6 +366,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpszCmdLi
 	swapchain_opts.create_time.gpu_frame_count = 2;
 	swapchain_opts.create_time.swapchain_buffer_count = 3;
 	swapchain_opts.create_time.use_waitable_object = 1;
+	swapchain_opts.create_time.allow_tearing = 0;
 	swapchain_opts.create_time.max_frame_latency = 2;
 
 	if (initialize_dx12(&swapchain_opts))


### PR DESCRIPTION
The stats with and without tearing allowed don't seem to be much different when the values stabilize. Not sure if that's a sign of a problem, but at least the infrastructure is there.

Depending on settings, the stats and visualization seems to stall, but that happens without the change as well.